### PR TITLE
Adds absolute path to ssl/keys in server config

### DIFF
--- a/server/server.js
+++ b/server/server.js
@@ -17,8 +17,8 @@ var uberController = require('./uber/uberController')(userController);
 // for ssl server
 var fs = require('fs');
 var https = require('https');
-var privateKey  = fs.readFileSync('sslcerts/acrobaticspork.key', 'utf8');
-var certificate = fs.readFileSync('sslcerts/acrobaticspork.crt', 'utf8');
+var privateKey  = fs.readFileSync(__dirname+'/sslcerts/acrobaticspork.key', 'utf8');
+var certificate = fs.readFileSync(__dirname+'/sslcerts/acrobaticspork.crt', 'utf8');
 var credentials = {key: privateKey, cert: certificate};
 
 var isDeveloping = process.env.NODE_ENV !== 'production';


### PR DESCRIPTION
Fails as file not found while server starts up. This sets path to absolute to make it more reliable
